### PR TITLE
Ajout d'un système de backtesting simple

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # BackTesting
+
+This project provides a simple framework for testing trading strategies.
+
+## Files
+- `strategies.py` defines available strategies.
+- `main.py` runs a strategy from the command line.
+- `gui.py` offers a basic GUI to launch backtests and display an equity curve graph.
+

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,45 @@
+"""Simple GUI to run backtests and display results."""
+import tkinter as tk
+from tkinter import ttk
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+import matplotlib.pyplot as plt
+
+from strategies import STRATEGIES
+from main import generate_prices
+
+
+def run(strategy_name, figure):
+    prices = generate_prices()
+    result = STRATEGIES[strategy_name](prices)
+    figure.clf()
+    ax = figure.add_subplot(111)
+    result.equity_curve.plot(ax=ax)
+    ax.set_title(strategy_name)
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Equity")
+    canvas.draw()
+
+
+def start_gui():
+    root = tk.Tk()
+    root.title("Backtesting GUI")
+
+    strategy_var = tk.StringVar(value=list(STRATEGIES.keys())[0])
+
+    ttk.Label(root, text="Strategy:").pack(side=tk.LEFT, padx=5, pady=5)
+    strategy_menu = ttk.OptionMenu(root, strategy_var, strategy_var.get(), *STRATEGIES.keys())
+    strategy_menu.pack(side=tk.LEFT, padx=5, pady=5)
+
+    fig = plt.Figure(figsize=(6,4))
+    global canvas
+    canvas = FigureCanvasTkAgg(fig, master=root)
+    canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+
+    run_button = ttk.Button(root, text="Run", command=lambda: run(strategy_var.get(), fig))
+    run_button.pack(side=tk.LEFT, padx=5, pady=5)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    start_gui()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,31 @@
+"""Command line interface for running backtests."""
+import pandas as pd
+import numpy as np
+from strategies import STRATEGIES
+
+
+def generate_prices(n=200, seed=42):
+    rng = np.random.default_rng(seed)
+    returns = rng.normal(0, 0.01, size=n)
+    price = 100 * (1 + returns).cumprod()
+    return pd.Series(price)
+
+
+def run_backtest(strategy_name: str):
+    prices = generate_prices()
+    strategy_fn = STRATEGIES[strategy_name]
+    result = strategy_fn(prices)
+    return result
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Run backtests")
+    parser.add_argument("strategy", choices=list(STRATEGIES.keys()))
+    args = parser.parse_args()
+    result = run_backtest(args.strategy)
+    print(result.equity_curve)
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies.py
+++ b/strategies.py
@@ -1,0 +1,44 @@
+# Basic strategies for backtesting
+from dataclasses import dataclass
+import pandas as pd
+import numpy as np
+
+@dataclass
+class StrategyResult:
+    equity_curve: pd.Series
+
+
+def buy_and_hold(prices: pd.Series, initial_cash: float = 1000.0) -> StrategyResult:
+    """Simple buy and hold strategy."""
+    shares = initial_cash / prices.iloc[0]
+    equity = shares * prices
+    return StrategyResult(equity_curve=equity)
+
+
+def moving_average_crossover(prices: pd.Series, short_window: int = 20, long_window: int = 50, initial_cash: float = 1000.0) -> StrategyResult:
+    """Moving average crossover strategy."""
+    short_ma = prices.rolling(window=short_window).mean()
+    long_ma = prices.rolling(window=long_window).mean()
+    signal = (short_ma > long_ma).astype(int)
+    positions = signal.diff().fillna(0)
+
+    cash = initial_cash
+    shares = 0
+    equity_curve = []
+
+    for price, pos_change in zip(prices, positions):
+        if pos_change == 1:  # buy
+            shares = cash / price
+            cash = 0
+        elif pos_change == -1:  # sell
+            cash = shares * price
+            shares = 0
+        equity_curve.append(cash + shares * price)
+
+    return StrategyResult(equity_curve=pd.Series(equity_curve, index=prices.index))
+
+# Map strategy names to functions
+STRATEGIES = {
+    "Buy and Hold": buy_and_hold,
+    "MA Crossover": moving_average_crossover,
+}


### PR DESCRIPTION
## Summary
- define example strategies in `strategies.py`
- add `main.py` to run backtests from the command line
- create `gui.py` providing a small Tkinter interface
- document the repository in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841bb47723483228121afe2743d20b2